### PR TITLE
Add Undo support

### DIFF
--- a/plugins/webkitdrag/_source.css
+++ b/plugins/webkitdrag/_source.css
@@ -9,6 +9,10 @@ img::selection {
   color: rgba(0, 0, 0, 0);
 }
 
+img.cke-resize {
+  outline: 1px dashed #000;
+}
+
 #ckimgrsz {
   position: absolute;
   width: 0;
@@ -24,7 +28,7 @@ img::selection {
   height: 0;
   background-size: 100% 100%;
   opacity: .65;
-  outline: 1px dashed black;
+  outline: 1px dashed #000;
 }
 
 #ckimgrsz span {

--- a/plugins/webkitdrag/plugin.js
+++ b/plugins/webkitdrag/plugin.js
@@ -24,7 +24,7 @@
       }
 
       // CSS is added in a compressed form
-      CKEDITOR.addCss('img::selection{color:rgba(0,0,0,0)}#ckimgrsz{position:absolute;width:0;height:0;cursor:default}#ckimgrsz .preview{position:absolute;top:0;left:0;width:0;height:0;background-size:100% 100%;opacity:.65;outline:1px dashed #000}#ckimgrsz span{position:absolute;width:5px;height:5px;background:#fff;border:1px solid #000}#ckimgrsz span:hover,#ckimgrsz span.active{background:#000}#ckimgrsz span.tl,#ckimgrsz span.br{cursor:nwse-resize}#ckimgrsz span.tm,#ckimgrsz span.bm{cursor:ns-resize}#ckimgrsz span.tr,#ckimgrsz span.bl{cursor:nesw-resize}#ckimgrsz span.lm,#ckimgrsz span.rm{cursor:ew-resize}body.dragging-tl,body.dragging-tl *,body.dragging-br,body.dragging-br *{cursor:nwse-resize!important}body.dragging-tm,body.dragging-tm *,body.dragging-bm,body.dragging-bm *{cursor:ns-resize!important}body.dragging-tr,body.dragging-tr *,body.dragging-bl,body.dragging-bl *{cursor:nesw-resize!important}body.dragging-lm,body.dragging-lm *,body.dragging-rm,body.dragging-rm *{cursor:ew-resize!important}');
+      CKEDITOR.addCss('img::selection{color:rgba(0,0,0,0)}img.cke-resize {outline: 1px dashed #000}#ckimgrsz{position:absolute;width:0;height:0;cursor:default}#ckimgrsz .preview{position:absolute;top:0;left:0;width:0;height:0;background-size:100% 100%;opacity:.65;outline:1px dashed #000}#ckimgrsz span{position:absolute;width:5px;height:5px;background:#fff;border:1px solid #000}#ckimgrsz span:hover,#ckimgrsz span.active{background:#000}#ckimgrsz span.tl,#ckimgrsz span.br{cursor:nwse-resize}#ckimgrsz span.tm,#ckimgrsz span.bm{cursor:ns-resize}#ckimgrsz span.tr,#ckimgrsz span.bl{cursor:nesw-resize}#ckimgrsz span.lm,#ckimgrsz span.rm{cursor:ew-resize}body.dragging-tl,body.dragging-tl *,body.dragging-br,body.dragging-br *{cursor:nwse-resize!important}body.dragging-tm,body.dragging-tm *,body.dragging-bm,body.dragging-bm *{cursor:ns-resize!important}body.dragging-tr,body.dragging-tr *,body.dragging-bl,body.dragging-bl *{cursor:nesw-resize!important}body.dragging-lm,body.dragging-lm *,body.dragging-rm,body.dragging-rm *{cursor:ew-resize!important}');
     },
     init: function(editor) {
       // This plugin only applies to Webkit
@@ -59,13 +59,14 @@
         e.preventDefault();
         e.stopPropagation();
         this.target = e.target;
+        this.attr = e.target.className;
         this.startPos = {x: e.clientX, y: e.clientY};
         this.update(e);
         var events = this.events;
         document.addEventListener('mousemove', events.mousemove, false);
         document.addEventListener('keydown', events.keydown, false);
         document.addEventListener('mouseup', events.mouseup, false);
-        body.className += ' dragging-' + this.attr
+        body.className += ' dragging-' + this.attr;
         this.onStart && this.onStart();
       },
       update: function(e) {
@@ -146,7 +147,7 @@
         handles.br = document.createElement('span');
         handles.br.className = 'br';
         for (var n in handles) {
-          preview.appendChild(handles[n]);
+          container.appendChild(handles[n]);
         }
       },
       show: function() {
@@ -223,9 +224,7 @@
           handles[n].style.display = 'block';
           handles[n].addEventListener('mousedown', this.events.initDrag, false);
         }
-        this.calculateSize();
-        this.updatePreview();
-        this.preview.style.display = 'block';
+        this.el.className += ' cke-resize';
       },
       hideHandles: function() {
         var handles = this.handles;
@@ -233,10 +232,19 @@
           handles[n].removeEventListener('mousedown', this.events.initDrag, false);
           handles[n].style.display = 'none';
         }
-        this.preview.style.display = 'none';
+        this.el.className = this.el.className.replace(' cke-resize', '');
+        console.log(this.el.className);
       },
       showPreview: function() {
         this.preview.style.backgroundImage = 'url("' + this.el.src + '")';
+        this.preview.style.display = 'block';
+        // Move handles to the preview so they resize with it.
+        for (var n in this.handles) {
+          this.preview.appendChild(this.handles[n]);
+        }
+        this.calculateSize();
+        this.updatePreview();
+        this.preview.style.display = 'block';
       },
       updatePreview: function() {
         var box = this.previewBox;
@@ -246,9 +254,13 @@
         this.preview.style.height = box.height + 'px';
       },
       hidePreview: function() {
-        this.preview.style.backgroundImage = 'none';
         var box = getBoundingBox(window, this.preview);
         this.result = {width: box.width, height: box.height};
+        // Move handles back to the wrapping container.
+        for (var n in this.handles) {
+          this.container.appendChild(this.handles[n]);
+        }
+        this.preview.style.display = 'none';
       },
       calculateSize: function(data) {
         var box = this.previewBox = {top: 0, left: 0, width: this.box.width, height: this.box.height};


### PR DESCRIPTION
Thanks for the great plugin. It needed a small amount tweaking to get it working with CKEditor 4.x, but it works great!

I found a few issues with the plugin that I addressed in this patch. Unfortunately I combined all the changes, which include:
- Added undo support so you can go back to your previously sized image.
- The resize handles are moved to inside the "preview" div. This makes it so that the handles resize with the rest of the preview instead of disappearing once you start dragging.
- Consolidated the CSS to use double-ended arrows (i.e. nwse-resize instead of nw-resize), since you can scale images down as well as up.
- Added a resize monitor to adjust the position of the handles when resizing the editor or entire window.
- And of course this now works on CKEditor 4.x. I believe this is compatible with CKEditor 3.x still.
